### PR TITLE
Fix item type validation in NPC generator

### DIFF
--- a/scripts/npc-generator.js
+++ b/scripts/npc-generator.js
@@ -246,7 +246,7 @@ The response MUST be a valid JSON array containing only the generated NPCs.
                     // 2. Items erstellen und zum Actor hinzufügen
                     if (npcData.items && Array.isArray(npcData.items)) {
                         const itemsToCreate = [];
-                        const validItemTypes = game.system.documentTypes.Item; // Gültige Item-Typen des Systems
+                        const validItemTypes = getValidItemTypes(); // Gültige Item-Typen des Systems
 
                         for (const item of npcData.items) {
                             // Prüfe, ob der Item-Typ gültig ist, bevor das Item erstellt wird


### PR DESCRIPTION
## Summary
- use helper to retrieve valid item types

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685317015848832cad0a6269264e17d8