### PR TITLE
Improve biography prompt

### DIFF
--- a/scripts/npc-generator.js
+++ b/scripts/npc-generator.js
@@ -129,7 +129,7 @@ class NPCGeneratorDialog extends FormApplication {
 Generate ${numNpcs} D&D5e NPCs as a JSON array. Each NPC must have the following structure:
 - "name": String, the NPC's name.
 - "type": String, the NPC type (for D&D5e usually "npc" or "character").
-- "description": String, a short description of the NPC.
+- "description": String, a brief biography of the NPC with at least three sentences.
 - "species": String representing the NPC's species.
 - "background": String describing the NPC's background.
 - "abilities": { "str": Number, "dex": Number, "con": Number, "int": Number, "wis": Number, "cha": Number }.


### PR DESCRIPTION
## Summary
- fine-tune the prompt so that NPC descriptions are longer

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685339352538832c9183689248e8fc04