### PR TITLE
Fix damage spell output

### DIFF
--- a/scripts/npc-generator.js
+++ b/scripts/npc-generator.js
@@ -174,9 +174,10 @@ For "tool":
     "proficient": true
   }
 
-For "spell":
+For "spell" (include damage.parts for damage-dealing spells):
   "system": {
     "description": {"value": "A description of the spell."},
+    "damage": {"parts": [["1d8", "fire"]]}, // Example damage for damage spells
     "level": 1,
     "school": "abj", // Or evn, nec, etc.
     "components": {"v": true, "s": true, "m": false},


### PR DESCRIPTION
## Summary
- include example damage for spells in the base prompt

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685343ad3544832cbefb343d98513932