### PR TITLE
Add requirement for multiple spells

### DIFF
--- a/scripts/npc-generator.js
+++ b/scripts/npc-generator.js
@@ -190,10 +190,11 @@ For "spell" (include damage.parts for damage-dealing spells):
     "level": 1,
     "school": "abj", // Or evn, nec, etc.
     "components": {"v": true, "s": true, "m": false},
-    "preparation": {"mode": "prepared", "prepared": true}
+  "preparation": {"mode": "prepared", "prepared": true}
   }
 
 Only use official D&D5e spells from the compendium and never invent new spells.
+Spellcasting NPCs (wizards, sorcerers, etc.) must include at least two spells in their items array so that they have multiple options.
 
 The response MUST be a valid JSON array containing only the generated NPCs.
 `;


### PR DESCRIPTION
## Summary
- update ChatGPT prompt to provide at least two spells for spellcasters

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6853b1720830832cacb35238b278305d