### PR TITLE
Clarify number of spells per NPC

### DIFF
--- a/scripts/npc-generator.js
+++ b/scripts/npc-generator.js
@@ -194,7 +194,7 @@ For "spell" (include damage.parts for damage-dealing spells):
   }
 
 Only use official D&D5e spells from the compendium and never invent new spells.
-Spellcasting NPCs (wizards, sorcerers, etc.) must include at least two spells in their items array so that they have multiple options.
+Spellcasting NPCs (wizards, sorcerers, etc.) must include spells in their items array. The number of spells should fit the NPC's challenge rating and be between 1 and 10 so that they have multiple options.
 
 The response MUST be a valid JSON array containing only the generated NPCs.
 `;


### PR DESCRIPTION
## Summary
- update NPC generation prompt to specify number of spells should depend on CR and stay between 1–10

## Testing
- `pre-commit` *(fails: no hooks installed)*

------
https://chatgpt.com/codex/tasks/task_e_6853b2fde7f0832cbae3da2a243a1279