### PR TITLE
Add max token setting for NPC generation

### DIFF
--- a/scripts/npc-generator.js
+++ b/scripts/npc-generator.js
@@ -113,6 +113,8 @@ class NPCGeneratorDialog extends FormApplication {
         const customModel = formData.get("customModel"); // Benutzerdefiniertes OpenAI-Modell
         const temperature = parseFloat(formData.get("temperature")); // Kreativität des Modells
         const topP = parseFloat(formData.get("topP")); // Diversität der Antworten
+        const maxTokensInput = parseInt(formData.get("maxTokens"));
+        const maxTokens = isNaN(maxTokensInput) || maxTokensInput <= 0 ? 1024 : maxTokensInput; // Maximale Tokenzahl
 
         // Validierung der Eingabe für die Anzahl der NPCs
         if (isNaN(numNpcs) || numNpcs <= 0) {
@@ -234,6 +236,7 @@ The response MUST be a valid JSON array containing only the generated NPCs.
             }],
             temperature: temperature,
             top_p: topP,
+            max_tokens: maxTokens,
             response_format: { "type": "json_object" } // Erzwingt JSON-Ausgabe von OpenAI (für neuere Modelle)
         });
 

--- a/templates/npc-generator.html
+++ b/templates/npc-generator.html
@@ -25,6 +25,11 @@
   </div>
 
   <div class="form-group">
+    <label for="maxTokens">Max Tokens</label>
+    <input type="number" name="maxTokens" id="maxTokens" value="1024" min="1"/>
+  </div>
+
+  <div class="form-group">
     <button type="button" class="generate-button">NPC generieren</button>
     <button type="button" class="openai-key-button">OpenAI Schlüssel einstellen</button>
   </div>


### PR DESCRIPTION
## Summary
- allow setting `max_tokens` for OpenAI requests
- add matching field to dialog UI

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6853bc4756e8832c98fef33f5a334127