### PR TITLE
Update max token default to 2000

### DIFF
--- a/scripts/npc-generator.js
+++ b/scripts/npc-generator.js
@@ -114,7 +114,7 @@ class NPCGeneratorDialog extends FormApplication {
         const temperature = parseFloat(formData.get("temperature")); // Kreativität des Modells
         const topP = parseFloat(formData.get("topP")); // Diversität der Antworten
         const maxTokensInput = parseInt(formData.get("maxTokens"));
-        const maxTokens = isNaN(maxTokensInput) || maxTokensInput <= 0 ? 1024 : maxTokensInput; // Maximale Tokenzahl
+        const maxTokens = isNaN(maxTokensInput) || maxTokensInput <= 0 ? 2000 : maxTokensInput; // Maximale Tokenzahl
 
         // Validierung der Eingabe für die Anzahl der NPCs
         if (isNaN(numNpcs) || numNpcs <= 0) {

--- a/templates/npc-generator.html
+++ b/templates/npc-generator.html
@@ -26,7 +26,7 @@
 
   <div class="form-group">
     <label for="maxTokens">Max Tokens</label>
-    <input type="number" name="maxTokens" id="maxTokens" value="1024" min="1"/>
+    <input type="number" name="maxTokens" id="maxTokens" value="2000" min="1"/>
   </div>
 
   <div class="form-group">


### PR DESCRIPTION
## Summary
- raise default max token count to 2000 in the generator script
- update the HTML template with the new default

## Testing
- `grep -n 2000 -R`

------
https://chatgpt.com/codex/tasks/task_e_6853befe2528832c80f2b7d4b4f710f1